### PR TITLE
EC2 RI function aliases

### DIFF
--- a/.claspignore
+++ b/.claspignore
@@ -2,3 +2,4 @@ tmp/*
 node_modules/**
 node_modules/**/.*/**
 node_modules/**/.*
+scripts/*

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tmp/
 node_modules/
 .clasprc.json
 help_dialog.html
+src/functions/gen/*.ts

--- a/README.md
+++ b/README.md
@@ -23,22 +23,12 @@ The following services are currently supported with more to come:
 * EC2 instances (Linux and Windows)
 * Pricing options: ondemand and reserved
 
-## Functions
+## EC2 Functions
 
-### EC2 Instances
+### Parameters
 
-* `EC2(settingsRange, instType, region: optional)`: (`region` is optional and overrides `settingsRange`)
-* `EC2_OD(instType, region, platform)`
-* `EC2_LINUX_OD(instType, region)`
-* `EC2_RHEL_OD(instType, region)`
-* `EC2_SUSE_OD(instType, region)`
-* `EC2_WINDOWS_OD(instType, region)`
-* `EC2_LINUX_MSSQL_OD(instType, region, sqlLicense)`
-* `EC2_WINDOWS_MSSQL_OD(instType, region, sqlLicense)`
+These define the parameters used in the following functions and instance settings.
 
-_Parameters_
-
-* `settingsRange`: Either an explicit spreadsheet range or named range containing default instance type settings, see below.
 * `instType`: name of instance represented as `<class>.<size>`, eg `m5.xlarge`
 * `region`: name of AWS region, eg `us-east-1` and `eu-west-1`
 * `purchaseType`: name of the purchasing type, either `ondemand` or `reserved`
@@ -48,22 +38,67 @@ _Parameters_
 * `purchaseTerm`: duration of reserved instance purchase in years, either `1` or `3`
 * `paymentOption`: payment option of reserved instance, either `no_upfront`, `partial_upfront`, or `all_upfront`
 
-### Default instance settings
+### Generic EC2 Function
 
-To minimize repetition of standard instance type properties, the `EC2()` function accepts a range parameter that points to preconfigured instance properties. The range may be an explicit one from the sheet, eg `A1:B4` or it may reference a [named range](https://support.google.com/docs/answer/63175). The range must be a 2 column x N row selection, where the first column in the row is the property name and the second column in the row is the property value. The supported property names and the supported values match the function parameters above.
+To minimize the repetition of standard instance pricing details, the `EC2()` function accepts a range parameter that points to pre-configured instance properties. The range may be an explicit one from the sheet, eg `A1:B4` or it may reference a [named range](https://support.google.com/docs/answer/63175). The range must be a 2 column x N row selection, where the first column in the row is the property name and the second column in the row is the property value.
+
+This approach makes it simple to define per-environment or per-organization pricing policy defaults and reference them per unique instance type.
+
+* `EC2(settingsRange, instType, region: optional)`: (`region` is optional and overrides `settingsRange`)
+
+ The supported property names and the supported values match the parameters defined earlier. The following parameters are required:
 
 * `region`
 * `platform`
 * `purchase_type`
 
-If the `purchase_type` is `reserved`, the following settings are required:
+If the `purchase_type` is `reserved`, you must also specify the following parameters:
 
 * `offering_class`
 * `purchase_term`
 * `payment_option`
 
+The add-on provides an easy way to configure and generate a named range of configuration settings. Find the "AWS Pricing" menu under the "Add-ons" top-level menu and select _"New settings sheet"_. This will popup a dialog to configure and generate a new sheet and a named settings range.
 
-The add-on provides an easy way to configure and generate a named range of configuration settings. Find the "AWS Pricing" menu under the "Add-ons" top-level menu and select "New settings sheet". This will popup a dialog to configure and generate a new sheet with named settings range.
+### EC2 On-demand Functions
+
+To explicitly grab on-demand pricing use these functions:
+
+* `EC2_OD(instType, region, platform)`
+* `EC2_LINUX_OD(instType, region)`
+* `EC2_RHEL_OD(instType, region)`
+* `EC2_SUSE_OD(instType, region)`
+* `EC2_WINDOWS_OD(instType, region)`
+* `EC2_LINUX_MSSQL_OD(instType, region, sqlLicense)`
+* `EC2_WINDOWS_MSSQL_OD(instType, region, sqlLicense)`
+
+### EC2 RI Functions
+
+The simplest EC2 RI function requires multiple parameters to specify all the RI pricing details:
+
+* `EC2_RI(instanceType, region, platform, offeringClass, purchaseTerm, paymentOption)`
+
+There are also several alias functions that encode the pricing details in the function name. They follow the form:
+```
+ EC2_<platform>_<STD or CONV>_RI_<NO, PARTIAL, or ALL>(instanceType, region, purchaseTerm)
+```
+
+* `STD` or `CONV` represent a *standard* or *convertible* RI, respectively
+* `NO`, `PARTIAL` or `ALL` represent whether it's a *no-upfront*, *partial-upfront* or *all-upfront* payment option, respectively
+
+For example, these are some of the alias functions:
+
+* `EC2_LINUX_CONV_RI_NO(instanceType, region, purchaseTerm)`
+* `EC2_LINUX_STD_RI_PARTIAL(instanceType, region, purchaseTerm)`
+* `EC2_LINUX_STD_RI_PARTIAL(instanceType, region, purchaseTerm)`
+
+Lastly, if you want pricing for MSSQL platforms you can use similar functions of the form:
+```
+ EC2_<platform>_MSSQL_<STD or CONV>_RI_<NO, PARTIAL, or ALL>(instanceType, region, sqlLicense, purchaseTerm)
+```
+
+Where `sqlLicense` is either *web*, *std*, or *enterprise* and `platform` is either *LINUX* or *WINDOWS*.
+
 
 ### Pricing Duration
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The following services are currently supported with more to come:
 
 These define the parameters used in the following functions and instance settings.
 
-* `instType`: name of instance represented as `<class>.<size>`, eg `m5.xlarge`
+* `instanceType`: name of instance represented as `<class>.<size>`, eg `m5.xlarge`
 * `region`: name of AWS region, eg `us-east-1` and `eu-west-1`
 * `purchaseType`: name of the purchasing type, either `ondemand` or `reserved`
 * `platform`: name of OS platform, currently supports: `linux`, `windows`, `rhel`, `suse`, `linux_std` (Linux SQL Standard), `linux_web` (Linux SQL Web), `linux_enterprise` (Linux SQL Enterprise), `windows_std` (Windows SQL Std), `windows_web` (Windows SQL Web), `windows_enterprise` (Windows SQL Enterprise)
@@ -44,7 +44,7 @@ To minimize the repetition of standard instance pricing details, the `EC2()` fun
 
 This approach makes it simple to define per-environment or per-organization pricing policy defaults and reference them per unique instance type.
 
-* `EC2(settingsRange, instType, region: optional)`: (`region` is optional and overrides `settingsRange`)
+* `EC2(settingsRange, instanceType, region: optional)`: (`region` is optional and overrides `settingsRange`)
 
  The supported property names and the supported values match the parameters defined earlier. The following parameters are required:
 
@@ -64,13 +64,13 @@ The add-on provides an easy way to configure and generate a named range of confi
 
 To explicitly grab on-demand pricing use these functions:
 
-* `EC2_OD(instType, region, platform)`
-* `EC2_LINUX_OD(instType, region)`
-* `EC2_RHEL_OD(instType, region)`
-* `EC2_SUSE_OD(instType, region)`
-* `EC2_WINDOWS_OD(instType, region)`
-* `EC2_LINUX_MSSQL_OD(instType, region, sqlLicense)`
-* `EC2_WINDOWS_MSSQL_OD(instType, region, sqlLicense)`
+* `EC2_OD(instanceType, region, platform)`
+* `EC2_LINUX_OD(instanceType, region)`
+* `EC2_RHEL_OD(instanceType, region)`
+* `EC2_SUSE_OD(instanceType, region)`
+* `EC2_WINDOWS_OD(instanceType, region)`
+* `EC2_LINUX_MSSQL_OD(instanceType, region, sqlLicense)`
+* `EC2_WINDOWS_MSSQL_OD(instanceType, region, sqlLicense)`
 
 ### EC2 RI Functions
 

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
   },
   "scripts": {
     "marked": "marked",
+    "gencode": "./scripts/gen-funcs.rb",
     "build-help": "./scripts/build-help.sh",
-    "deploy": "npm run build-help && clasp push",
+    "deploy": "npm run gencode && npm run build-help && clasp push",
     "release": "npm run deploy && ./scripts/release.sh",
     "test": "npm run deploy && echo && clasp run runAllTests"
   },

--- a/scripts/gen-funcs.rb
+++ b/scripts/gen-funcs.rb
@@ -6,7 +6,7 @@ topdir = File.join(from, "..")
 outfilename = 'ec2_ri_gen.ts'
 outfile = File.join(topdir, 'src/functions/gen', outfilename)
 
-f = File.open(outfile, File::CREAT|File::TRUNC|File::WRONLY, 0644)
+f = File.open(outfile, File::CREAT|File::TRUNC|File::WRONLY, 0664)
 
 f.write <<~EOF
 /* DO NOT EDIT -- this file is generated */

--- a/scripts/gen-funcs.rb
+++ b/scripts/gen-funcs.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+
+from = File.expand_path(File.dirname(__FILE__))
+topdir = File.join(from, "..")
+
+outfilename = 'ec2_ri_gen.ts'
+outfile = File.join(topdir, 'src/functions/gen', outfilename)
+
+f = File.open(outfile, File::CREAT|File::TRUNC|File::WRONLY, 0644)
+
+f.write <<~EOF
+/* DO NOT EDIT -- this file is generated */
+
+import { EC2_RI } from "../ec2_ri";
+import { EC2Platform } from "../../models/ec2_platform";
+
+EOF
+
+platforms = ["linux", "rhel", "suse", "windows"]
+ri_classes = {
+    "convertible" => "conv",
+    "standard" => "std"
+}
+
+payment_options = {
+    "no_upfront" => "no",
+    "partial_upfront" => "partial",
+    "all_upfront" => "all"
+}
+
+platforms.each do |platform|
+    ri_classes.each do |ri_class|
+        payment_options.each do |payment_option|
+            func = <<~EOF
+            /**
+             * Returns the RI pricing for an instance type with a #{ri_class[0]}, #{payment_option[0].gsub("_", "-")} RI using #{platform}.
+             *
+             * @param instanceType
+             * @param region
+             * @param purchaseTerm in years (1 or 3)
+             * @returns price
+             * @customfunction
+             */
+            export function EC2_#{platform.upcase}_#{ri_class[1].upcase}_RI_#{payment_option[1].upcase}(instanceType: string, region: string, purchaseTerm: string) {
+                return EC2_RI(instanceType, region, "#{platform}", "#{ri_class[0]}", purchaseTerm, "#{payment_option[0]}")
+            }
+
+EOF
+            f.write(func)
+        end
+    end
+end
+
+sql_platforms = ["linux", "windows"]
+
+sql_platforms.each do |sql_platform|
+    ri_classes.each do |ri_class|
+        payment_options.each do |payment_option|
+            func = <<~EOF
+            /**
+             * Returns the RI pricing for an instance type with a #{ri_class[0]}, #{payment_option[0].gsub("_", "-")} RI using #{sql_platform} SQL.
+             *
+             * @param instanceType
+             * @param region
+             * @param sqlLicense (std, web, or enterprise)
+             * @param purchaseTerm in years (1 or 3)
+             * @returns price
+             * @customfunction
+             */
+            export function EC2_#{sql_platform.upcase}_MSSQL_#{ri_class[1].upcase}_RI_#{payment_option[1].upcase}(instanceType: string, region: string, sqlLicense: string, purchaseTerm: string) {
+                return EC2_RI(instanceType, region, EC2Platform.msSqlLicenseToType("#{sql_platform}", sqlLicense), "#{ri_class[0]}", purchaseTerm, "#{payment_option[0]}")
+            }
+
+EOF
+            f.write(func)
+        end
+    end
+end
+
+f.close

--- a/src/functions/ec2.ts
+++ b/src/functions/ec2.ts
@@ -4,8 +4,8 @@ import { InvocationSettings } from "../settings/invocation_settings";
 import { _initContext } from "../context";
 import { SettingKeys } from "../settings/setting_keys";
 
-export function _ec2(settings: InvocationSettings, instType: string)  {
-    if (!instType) {
+export function _ec2(settings: InvocationSettings, instanceType: string)  {
+    if (!instanceType) {
         throw "Instance type is not set"
     }
 
@@ -14,16 +14,16 @@ export function _ec2(settings: InvocationSettings, instType: string)  {
         throw msg
     }
 
-    let ec2Prices = new EC2Price(settings, instType)
+    let ec2Prices = new EC2Price(settings, instanceType)
 
     return ec2Prices.get(PriceDuration.Hourly)
 }
 
-export function _ec2_full(instType: string, region: string, purchaseType: string, platform: string,
+export function _ec2_full(instanceType: string, region: string, purchaseType: string, platform: string,
     offeringClass?: string, purchaseTerm?: string, paymentOption?: string) {
     _initContext()
 
-    if (!instType) {
+    if (!instanceType) {
         throw "Instance type is not set"
     }
 
@@ -64,5 +64,5 @@ export function _ec2_full(instType: string, region: string, purchaseType: string
 
     let settings = InvocationSettings.loadFromMap(settingsMap)
 
-    return _ec2(settings, instType)
+    return _ec2(settings, instanceType)
 }

--- a/src/functions/ec2.ts
+++ b/src/functions/ec2.ts
@@ -1,11 +1,10 @@
-import { EC2Platform } from "../models/ec2_platform";
-import { InvocationSettings } from "../settings/invocation_settings";
 import { PriceDuration } from "../price_converter";
 import { EC2Price } from "../ec2_price";
+import { InvocationSettings } from "../settings/invocation_settings";
 import { _initContext } from "../context";
 import { SettingKeys } from "../settings/setting_keys";
 
-function _ec2(settings: InvocationSettings, instType: string)  {
+export function _ec2(settings: InvocationSettings, instType: string)  {
     if (!instType) {
         throw "Instance type is not set"
     }
@@ -20,7 +19,8 @@ function _ec2(settings: InvocationSettings, instType: string)  {
     return ec2Prices.get(PriceDuration.Hourly)
 }
 
-function _ec2_full(instType: string, region: string, purchaseType: string, platform: string) {
+export function _ec2_full(instType: string, region: string, purchaseType: string, platform: string,
+    offeringClass?: string, purchaseTerm?: string, paymentOption?: string) {
     _initContext()
 
     if (!instType) {
@@ -44,121 +44,25 @@ function _ec2_full(instType: string, region: string, purchaseType: string, platf
     settingsMap[SettingKeys.PurchaseType] = purchaseType
     settingsMap[SettingKeys.Platform] = platform
 
+    if (purchaseType === "reserved") {
+        if (!offeringClass) {
+            throw "Offering class is not set"
+        }
+
+        if (!purchaseTerm) {
+            throw "Purchase term is not set"
+        }
+
+        if (!paymentOption) {
+            throw "Payment option is not set"
+        }
+
+        settingsMap[SettingKeys.OfferingClass] = offeringClass
+        settingsMap[SettingKeys.PurchaseTerm] = purchaseTerm
+        settingsMap[SettingKeys.PaymentOption] = paymentOption
+    }
+
     let settings = InvocationSettings.loadFromMap(settingsMap)
 
     return _ec2(settings, instType)
-}
-
-/**
- * Returns the on-demand pricing for given instance type using the provided settings.
- * 
- * @param settingsRange Two-column range of default EC2 instance settngs
- * @param instType Instance type, eg. "m5.xlarge"
- * @param region Override region setting for this call (optional)
- * @returns price
- * @customfunction
- */
-export function EC2(settingsRange: Array<Array<string>>, instType: string, region?: string) {
-    _initContext()
-
-    if (!settingsRange) {
-        throw "Missing required settings range"
-    }
-
-    let overrides = {}
-
-    if (region) {
-        overrides[SettingKeys.Region] = region
-    }
-
-    let settings = InvocationSettings.loadFromRange(settingsRange, overrides)
-
-    return _ec2(settings, instType)
-}
-
-/**
- * Returns the on-demand pricing for given instance type.
- * 
- * @param instType
- * @param region
- * @param platform
- * @returns price
- * @customfunction
- */
-export function EC2_OD(instType: string, region: string, platform: string) {
-    return _ec2_full(instType, region, "ondemand", platform)
-}
-
-/**
- * Returns the on-demand pricing for given instance type, using Linux.
- * 
- * @param instType
- * @param region
- * @returns price
- * @customfunction
- */
-export function EC2_LINUX_OD(instType: string, region: string) {
-    return EC2_OD(instType, region, "linux")
-}
-
-/**
- * Returns the on-demand pricing for given instance type, using Linux SQL.
- * 
- * @param instType
- * @param region
- * @param sqlLicense (std, web, or enterprise)
- * @returns price
- * @customfunction
- */
-export function EC2_LINUX_MSSQL_OD(instType: string, region: string, sqlLicense: string) {
-    return EC2_OD(instType, region, EC2Platform.msSqlLicenseToType("linux", sqlLicense))
-}
-
-/**
- * Returns the on-demand pricing for given instance type, using RHEL.
- * 
- * @param instType
- * @param region
- * @returns price
- * @customfunction
- */
-export function EC2_RHEL_OD(instType: string, region: string) {
-    return EC2_OD(instType, region, "rhel")
-}
-
-/**
- * Returns the on-demand pricing for given instance type, using SUSE.
- * 
- * @param instType
- * @param region
- * @returns price
- * @customfunction
- */
-export function EC2_SUSE_OD(instType: string, region: string) {
-    return EC2_OD(instType, region, "suse")
-}
-
-/**
- * Returns the on-demand pricing for given instance type, using Windows.
- * 
- * @param instType
- * @param region
- * @returns price
- * @customfunction
- */
-export function EC2_WINDOWS_OD(instType: string, region: string) {
-    return EC2_OD(instType, region, "windows")
-}
-
-/**
- * Returns the on-demand pricing for given instance type, using Windows SQL.
- * 
- * @param instType
- * @param region
- * @param sqlLicense
- * @returns price
- * @customfunction
- */
-export function EC2_WINDOWS_MSSQL_OD(instType: string, region: string, sqlLicense: string) {
-    return EC2_OD(instType, region, EC2Platform.msSqlLicenseToType("windows", sqlLicense))
 }

--- a/src/functions/ec2_od.ts
+++ b/src/functions/ec2_od.ts
@@ -8,12 +8,12 @@ import { _ec2, _ec2_full } from "./ec2";
  * Returns the on-demand pricing for given instance type using the provided settings.
  *
  * @param settingsRange Two-column range of default EC2 instance settngs
- * @param instType Instance type, eg. "m5.xlarge"
+ * @param instanceType Instance type, eg. "m5.xlarge"
  * @param region Override region setting for this call (optional)
  * @returns price
  * @customfunction
  */
-export function EC2(settingsRange: Array<Array<string>>, instType: string, region?: string) {
+export function EC2(settingsRange: Array<Array<string>>, instanceType: string, region?: string) {
     _initContext()
 
     if (!settingsRange) {
@@ -28,92 +28,92 @@ export function EC2(settingsRange: Array<Array<string>>, instType: string, regio
 
     let settings = InvocationSettings.loadFromRange(settingsRange, overrides)
 
-    return _ec2(settings, instType)
+    return _ec2(settings, instanceType)
 }
 
 /**
  * Returns the on-demand pricing for given instance type.
  *
- * @param instType
+ * @param instanceType
  * @param region
  * @param platform
  * @returns price
  * @customfunction
  */
-export function EC2_OD(instType: string, region: string, platform: string) {
-    return _ec2_full(instType, region, "ondemand", platform)
+export function EC2_OD(instanceType: string, region: string, platform: string) {
+    return _ec2_full(instanceType, region, "ondemand", platform)
 }
 
 /**
  * Returns the on-demand pricing for given instance type, using Linux.
  *
- * @param instType
+ * @param instanceType
  * @param region
  * @returns price
  * @customfunction
  */
-export function EC2_LINUX_OD(instType: string, region: string) {
-    return EC2_OD(instType, region, "linux")
+export function EC2_LINUX_OD(instanceType: string, region: string) {
+    return EC2_OD(instanceType, region, "linux")
 }
 
 /**
  * Returns the on-demand pricing for given instance type, using Linux MS SQL.
  *
- * @param instType
+ * @param instanceType
  * @param region
  * @param sqlLicense (std, web, or enterprise)
  * @returns price
  * @customfunction
  */
-export function EC2_LINUX_MSSQL_OD(instType: string, region: string, sqlLicense: string) {
-    return EC2_OD(instType, region, EC2Platform.msSqlLicenseToType("linux", sqlLicense))
+export function EC2_LINUX_MSSQL_OD(instanceType: string, region: string, sqlLicense: string) {
+    return EC2_OD(instanceType, region, EC2Platform.msSqlLicenseToType("linux", sqlLicense))
 }
 
 /**
  * Returns the on-demand pricing for given instance type, using RHEL.
  *
- * @param instType
+ * @param instanceType
  * @param region
  * @returns price
  * @customfunction
  */
-export function EC2_RHEL_OD(instType: string, region: string) {
-    return EC2_OD(instType, region, "rhel")
+export function EC2_RHEL_OD(instanceType: string, region: string) {
+    return EC2_OD(instanceType, region, "rhel")
 }
 
 /**
  * Returns the on-demand pricing for given instance type, using SUSE.
  *
- * @param instType
+ * @param instanceType
  * @param region
  * @returns price
  * @customfunction
  */
-export function EC2_SUSE_OD(instType: string, region: string) {
-    return EC2_OD(instType, region, "suse")
+export function EC2_SUSE_OD(instanceType: string, region: string) {
+    return EC2_OD(instanceType, region, "suse")
 }
 
 /**
  * Returns the on-demand pricing for given instance type, using Windows.
  *
- * @param instType
+ * @param instanceType
  * @param region
  * @returns price
  * @customfunction
  */
-export function EC2_WINDOWS_OD(instType: string, region: string) {
-    return EC2_OD(instType, region, "windows")
+export function EC2_WINDOWS_OD(instanceType: string, region: string) {
+    return EC2_OD(instanceType, region, "windows")
 }
 
 /**
  * Returns the on-demand pricing for given instance type, using Windows MS SQL.
  *
- * @param instType
+ * @param instanceType
  * @param region
  * @param sqlLicense
  * @returns price
  * @customfunction
  */
-export function EC2_WINDOWS_MSSQL_OD(instType: string, region: string, sqlLicense: string) {
-    return EC2_OD(instType, region, EC2Platform.msSqlLicenseToType("windows", sqlLicense))
+export function EC2_WINDOWS_MSSQL_OD(instanceType: string, region: string, sqlLicense: string) {
+    return EC2_OD(instanceType, region, EC2Platform.msSqlLicenseToType("windows", sqlLicense))
 }

--- a/src/functions/ec2_od.ts
+++ b/src/functions/ec2_od.ts
@@ -1,0 +1,119 @@
+import { EC2Platform } from "../models/ec2_platform";
+import { InvocationSettings } from "../settings/invocation_settings";
+import { _initContext } from "../context";
+import { SettingKeys } from "../settings/setting_keys";
+import { _ec2, _ec2_full } from "./ec2";
+
+/**
+ * Returns the on-demand pricing for given instance type using the provided settings.
+ *
+ * @param settingsRange Two-column range of default EC2 instance settngs
+ * @param instType Instance type, eg. "m5.xlarge"
+ * @param region Override region setting for this call (optional)
+ * @returns price
+ * @customfunction
+ */
+export function EC2(settingsRange: Array<Array<string>>, instType: string, region?: string) {
+    _initContext()
+
+    if (!settingsRange) {
+        throw "Missing required settings range"
+    }
+
+    let overrides = {}
+
+    if (region) {
+        overrides[SettingKeys.Region] = region
+    }
+
+    let settings = InvocationSettings.loadFromRange(settingsRange, overrides)
+
+    return _ec2(settings, instType)
+}
+
+/**
+ * Returns the on-demand pricing for given instance type.
+ *
+ * @param instType
+ * @param region
+ * @param platform
+ * @returns price
+ * @customfunction
+ */
+export function EC2_OD(instType: string, region: string, platform: string) {
+    return _ec2_full(instType, region, "ondemand", platform)
+}
+
+/**
+ * Returns the on-demand pricing for given instance type, using Linux.
+ *
+ * @param instType
+ * @param region
+ * @returns price
+ * @customfunction
+ */
+export function EC2_LINUX_OD(instType: string, region: string) {
+    return EC2_OD(instType, region, "linux")
+}
+
+/**
+ * Returns the on-demand pricing for given instance type, using Linux MS SQL.
+ *
+ * @param instType
+ * @param region
+ * @param sqlLicense (std, web, or enterprise)
+ * @returns price
+ * @customfunction
+ */
+export function EC2_LINUX_MSSQL_OD(instType: string, region: string, sqlLicense: string) {
+    return EC2_OD(instType, region, EC2Platform.msSqlLicenseToType("linux", sqlLicense))
+}
+
+/**
+ * Returns the on-demand pricing for given instance type, using RHEL.
+ *
+ * @param instType
+ * @param region
+ * @returns price
+ * @customfunction
+ */
+export function EC2_RHEL_OD(instType: string, region: string) {
+    return EC2_OD(instType, region, "rhel")
+}
+
+/**
+ * Returns the on-demand pricing for given instance type, using SUSE.
+ *
+ * @param instType
+ * @param region
+ * @returns price
+ * @customfunction
+ */
+export function EC2_SUSE_OD(instType: string, region: string) {
+    return EC2_OD(instType, region, "suse")
+}
+
+/**
+ * Returns the on-demand pricing for given instance type, using Windows.
+ *
+ * @param instType
+ * @param region
+ * @returns price
+ * @customfunction
+ */
+export function EC2_WINDOWS_OD(instType: string, region: string) {
+    return EC2_OD(instType, region, "windows")
+}
+
+/**
+ * Returns the on-demand pricing for given instance type, using Windows MS SQL.
+ *
+ * @param instType
+ * @param region
+ * @param sqlLicense
+ * @returns price
+ * @customfunction
+ */
+export function EC2_WINDOWS_MSSQL_OD(instType: string, region: string, sqlLicense: string) {
+    return EC2_OD(instType, region, EC2Platform.msSqlLicenseToType("windows", sqlLicense))
+}

--- a/src/functions/ec2_ri.ts
+++ b/src/functions/ec2_ri.ts
@@ -1,0 +1,14 @@
+import { _ec2_full } from "./ec2";
+
+/**
+ * Returns the on-demand pricing for given instance type, using Linux.
+ * 
+ * @param instanceType
+ * @param region
+ * @returns price
+ * @customfunction
+ */
+export function EC2_RI(instanceType: string, region: string, platform: string, offeringClass: string,
+    purchaseTerm: string, paymentOption: string) {
+    return _ec2_full(instanceType, region, "reserved", platform, offeringClass, purchaseTerm, paymentOption)
+}

--- a/tests/functions/ec2_test.ts
+++ b/tests/functions/ec2_test.ts
@@ -1,6 +1,7 @@
-import { EC2_OD, EC2_LINUX_OD, EC2_WINDOWS_OD, EC2_RHEL_OD, EC2_SUSE_OD, EC2, EC2_LINUX_MSSQL_OD, EC2_WINDOWS_MSSQL_OD } from "../../src/functions/ec2";
+import { EC2_OD, EC2_LINUX_OD, EC2_WINDOWS_OD, EC2_RHEL_OD, EC2_SUSE_OD, EC2, EC2_LINUX_MSSQL_OD, EC2_WINDOWS_MSSQL_OD } from "../../src/functions/ec2_od";
 import { TestSuite } from "../_framework/test_suite";
 import { TestRun } from "../_framework/test_run";
+import { EC2_LINUX_CONV_RI_ALL, EC2_LINUX_MSSQL_CONV_RI_ALL, EC2_RHEL_CONV_RI_ALL, EC2_WINDOWS_MSSQL_STD_RI_PARTIAL } from "../../src/functions/gen/ec2_ri_gen";
 
 export class EC2FunctionTestSuite extends TestSuite {
     name() {
@@ -100,6 +101,13 @@ export class EC2FunctionTestSuite extends TestSuite {
             t.areClose(0.073706, EC2(this.linuxRi('us-east-1', 'standard', 3, 'all_upfront'), "m5.xlarge"), 0.00001)
 
             t.areClose(0.099201, EC2(this.linuxRi('us-west-1', 'standard', 3, 'all_upfront'), "m5.xlarge"), 0.00001)
+        })
+
+        t.describe("EC2 RI functions", () => {
+            t.areClose(0.131621, EC2_LINUX_CONV_RI_ALL("m5.xlarge", "us-east-1", "1"), 0.00001)
+            t.areClose(0.191667, EC2_RHEL_CONV_RI_ALL("m5.xlarge", "us-east-1", "1"), 0.00001)
+            t.areClose(0.199201, EC2_LINUX_MSSQL_CONV_RI_ALL("m5.xlarge", "us-east-1", "web", "1"), 0.00001)
+            t.areClose(0.742195, EC2_WINDOWS_MSSQL_STD_RI_PARTIAL("m5.xlarge", "us-east-2", "std", "3"), 0.00001)
         })
     }
 


### PR DESCRIPTION
Add alias functions that explicitly request RI pricing. These would be useful if you want mixed pricing details within a single sheet and don't want to use multiple settings ranges.

Given the number of functions, these are generated by a script.