### PR TITLE
Catch error when size (as number) is passed as vol type.

### DIFF
--- a/src/functions/ebs.ts
+++ b/src/functions/ebs.ts
@@ -20,7 +20,7 @@ function _ec2_ebs(settings: InvocationSettings, storageType: EBSStorageType, vol
     }
 
     if (volumeType) {
-        volumeType = volumeType.toLowerCase()
+        volumeType = volumeType.toString().toLowerCase()
     }
 
     let ebsPrices = new EBSPrice(settings, storageType, volumeType, volumeUnits.toString())

--- a/tests/functions/ebs_test.ts
+++ b/tests/functions/ebs_test.ts
@@ -72,6 +72,10 @@ export class EBSFunctionTestSuite extends TestSuite {
             t.willThrow(function() {
                 EC2_EBS_GP2_GB("foo", "us-east-1")
             }, "unable to parse volume units")
+
+            t.willThrow(function() {
+                EC2_EBS_GB(s, 400, "gp2")
+            }, "invalid EBS volume type")
         })
     }
 }


### PR DESCRIPTION
Must convert to string before attempting to convert to lower case.