### PR TITLE
Fix tests since db.r4 pricing is deprecated

### DIFF
--- a/tests/functions/rds_test.ts
+++ b/tests/functions/rds_test.ts
@@ -9,31 +9,31 @@ export class RDSFunctionTestSuite extends TestSuite {
     
     protected run(t: TestRun): void {
         t.describe("RDS func tests", () => {
-            t.areEqual(0.58, RDS_AURORA_MYSQL_OD("db.r4.xlarge", "us-east-1"))
-            t.areClose(0.379999, RDS_AURORA_MYSQL_RI("db.r4.xlarge", "us-east-1", 1, "no_upfront"), 0.000001)
-            t.areClose(0.322694, RDS_AURORA_MYSQL_RI("db.r4.xlarge", "us-east-1", 1, "partial_upfront"), 0.000001)
-            t.areClose(0.316210, RDS_AURORA_MYSQL_RI("db.r4.xlarge", "us-east-1", 1, "all_upfront"), 0.000001)
+            t.areEqual(0.58, RDS_AURORA_MYSQL_OD("db.r5.xlarge", "us-east-1"))
+            t.areClose(0.379999, RDS_AURORA_MYSQL_RI("db.r5.xlarge", "us-east-1", 1, "no_upfront"), 0.000001)
+            t.areClose(0.322694, RDS_AURORA_MYSQL_RI("db.r5.xlarge", "us-east-1", 1, "partial_upfront"), 0.000001)
+            t.areClose(0.316210, RDS_AURORA_MYSQL_RI("db.r5.xlarge", "us-east-1", 1, "all_upfront"), 0.000001)
 
             t.willThrow(function() {
-                RDS_AURORA_MYSQL_RI("db.r4.xlarge", "us-east-1", 3, "no_upfront")
+                RDS_AURORA_MYSQL_RI("db.r5.xlarge", "us-east-1", 3, "no_upfront")
             }, "not supported")
-            t.areClose(0.215129, RDS_AURORA_MYSQL_RI("db.r4.xlarge", "us-east-1", 3, "partial_upfront"), 0.000001)
-            t.areClose(0.202207, RDS_AURORA_MYSQL_RI("db.r4.xlarge", "us-east-1", 3, "all_upfront"), 0.000001)
+            t.areClose(0.215129, RDS_AURORA_MYSQL_RI("db.r5.xlarge", "us-east-1", 3, "partial_upfront"), 0.000001)
+            t.areClose(0.202207, RDS_AURORA_MYSQL_RI("db.r5.xlarge", "us-east-1", 3, "all_upfront"), 0.000001)
 
-            t.areClose(0.379999, RDS_AURORA_MYSQL_RI_NO("db.r4.xlarge", "us-east-1", 1), 0.000001)
-            t.areClose(0.322694, RDS_AURORA_MYSQL_RI_PARTIAL("db.r4.xlarge", "us-east-1", 1), 0.000001)
-            t.areClose(0.316210, RDS_AURORA_MYSQL_RI_ALL("db.r4.xlarge", "us-east-1", 1), 0.000001)
+            t.areClose(0.379999, RDS_AURORA_MYSQL_RI_NO("db.r5.xlarge", "us-east-1", 1), 0.000001)
+            t.areClose(0.322694, RDS_AURORA_MYSQL_RI_PARTIAL("db.r5.xlarge", "us-east-1", 1), 0.000001)
+            t.areClose(0.316210, RDS_AURORA_MYSQL_RI_ALL("db.r5.xlarge", "us-east-1", 1), 0.000001)
 
-            t.areEqual(1.16, RDS_AURORA_POSTGRESQL_OD("db.r4.2xlarge", "us-east-1"))
-            t.areEqual(1.04, RDS_MARIADB_OD("db.r4.2xlarge", "ca-central-1"))
-            t.areEqual(1.0809, RDS_POSTGRESQL_OD("DB.R4.2XLARGE", "CA-CENTRAL-1"))
-            t.areEqual(1.04, RDS_MYSQL_OD("db.r4.2xlarge", "ca-central-1"))
+            t.areEqual(1.16, RDS_AURORA_POSTGRESQL_OD("db.r5.2xlarge", "us-east-1"))
+            t.areEqual(1.04, RDS_MARIADB_OD("db.r5.2xlarge", "ca-central-1"))
+            t.areEqual(1.0810, RDS_POSTGRESQL_OD("db.r5.2XLARGE", "CA-CENTRAL-1"))
+            t.areEqual(1.04, RDS_MYSQL_OD("db.r5.2xlarge", "ca-central-1"))
 
             // Verify all RI purchase types to ensure payload sizes fit in cache
-            t.areClose(0.404452, RDS_AURORA_POSTGRESQL_RI("db.r4.2xlarge", "us-east-1", 3, "all_upfront"), 0.000001)
-            t.areClose(0.348097, RDS_MARIADB_RI("db.r4.2xlarge", "us-east-1", 3, "all_upfront"), 0.000001)
-            t.areClose(0.348097, RDS_MYSQL_RI("db.r4.2xlarge", "us-east-1", 3, "all_upfront"), 0.000001)
-            t.areClose(0.362595, RDS_POSTGRESQL_RI("db.r4.2xlarge", "us-east-1", 3, "all_upfront"), 0.000001)
+            t.areClose(0.404452, RDS_AURORA_POSTGRESQL_RI("db.r5.2xlarge", "us-east-1", 3, "all_upfront"), 0.000001)
+            t.areClose(0.348097, RDS_MARIADB_RI("db.r5.2xlarge", "us-east-1", 3, "all_upfront"), 0.000001)
+            t.areClose(0.348097, RDS_MYSQL_RI("db.r5.2xlarge", "us-east-1", 3, "all_upfront"), 0.000001)
+            t.areClose(0.362595, RDS_POSTGRESQL_RI("db.r5.2xlarge", "us-east-1", 3, "all_upfront"), 0.000001)
         })
 
         t.describe("RDS settings tests", () => {
@@ -42,8 +42,8 @@ export class RDSFunctionTestSuite extends TestSuite {
                 ['purchase_type', 'ondemand']
             ]
 
-            t.areEqual(0.58, RDS_AURORA_MYSQL(s, "db.r4.xlarge"))
-            t.areEqual(0.64, RDS_AURORA_MYSQL(s, "db.r4.xlarge", "ca-central-1"))
+            t.areEqual(0.58, RDS_AURORA_MYSQL(s, "db.r5.xlarge"))
+            t.areEqual(0.64, RDS_AURORA_MYSQL(s, "db.r5.xlarge", "ca-central-1"))
 
             s = [
                 ['region', 'us-east-1'],
@@ -52,9 +52,9 @@ export class RDSFunctionTestSuite extends TestSuite {
                 ['payment_option', 'partial_upfront']
             ]
 
-            t.areClose(0.322694, RDS_AURORA_MYSQL(s, "db.r4.xlarge"), 0.000001)
+            t.areClose(0.322694, RDS_AURORA_MYSQL(s, "db.r5.xlarge"), 0.000001)
             s[3][1] = 'all_upfront'
-            t.areClose(0.316210, RDS_AURORA_MYSQL(s, "db.r4.xlarge"), 0.000001)
+            t.areClose(0.316210, RDS_AURORA_MYSQL(s, "db.r5.xlarge"), 0.000001)
         })
 
         t.describe("RDS invalid settings", () => {
@@ -74,7 +74,7 @@ export class RDSFunctionTestSuite extends TestSuite {
             }, "must specify a db instance")
 
             t.willThrow(function() {
-                RDS_AURORA_MYSQL_RI("db.r4.xlarge", "us-east-1", 2, "no_upfront")
+                RDS_AURORA_MYSQL_RI("db.r5.xlarge", "us-east-1", 2, "no_upfront")
             }, "purchase_term")
         })
     }


### PR DESCRIPTION
Unfortunately, it appears that we can no longer pull pricing data for db.r4 from the original pricing files. Given this, we will swap db.r4->db.r5 in the RDS tests so that the test suite passes again. Fortunately, almost all the prices were identical so I only had to change one.

I don't know if there's a concept of previous generation pricing for RDS like there this EC2, but this will at least fix the tests for now.