### PR TITLE
Skip cache if file is too large.

### DIFF
--- a/src/cache_loader.ts
+++ b/src/cache_loader.ts
@@ -29,6 +29,12 @@ export class CacheLoader {
 
         let encoded = Utilities.base64Encode(gzBlob.getBytes())
 
+        // XXX: If we exceed the maximum length don't attempt to cache
+        //
+        if (encoded.length > 100_000) {
+            return
+        }
+
         if (expirationInSeconds) {
             this.cache.put(keyEncode, encoded, expirationInSeconds)
         } else {


### PR DESCRIPTION
This is a work around for the failures seen in #24. Unfortunately it would appear that the data files have exceeded the 100kb maximum permitted for a GAS cache value. It appears the source file is already about 4.5MB, while we strip some data out and compress it we are still sitting over 100kb.

We should really transform the doc into a much smaller payload format, but this is a quick fix for now.

Fixes #24 