### PR TITLE
Fix EBS snapshots

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -20,4 +20,16 @@ export class Utils {
     public static includes(str: string, substr: string): boolean {
         return str && str.indexOf(substr) !== -1
     }
+
+    public static endsWith(str: string, search: string): boolean {
+        if (!str) {
+            return false
+        }
+
+        if (search.length > str.length) {
+            return false
+        }
+
+        return str.substring(str.length - search.length, str.length) === search;
+    }
 }

--- a/src/ebs_price.ts
+++ b/src/ebs_price.ts
@@ -59,7 +59,11 @@ export class EBSPrice {
         }
 
         if (prices.length > 1) {
-            throw `Too many matches for EBS volume type ${this.volumeType}`
+            if (this.storageType === EBSStorageType.Snapshot) {
+                throw `Too many matches for EBS Snapshot storage`
+            } else {
+                throw `Too many matches for EBS volume type ${this.volumeType}`
+            }
         }
 
         let volumeUnitsNum = parseFloat(this.volumeUnits)

--- a/src/ebs_price.ts
+++ b/src/ebs_price.ts
@@ -87,10 +87,9 @@ export class EBSPrice {
 
     private filterPricesSnapshot(prices) {
         return prices.filter(price => {
-            return Utils.includes(price.attributes['aws:ec2:usagetype'], 'EBS:SnapshotUsage') &&
-
-                // XXX what is this?
-                !Utils.includes(price.attributes['aws:ec2:usagetype'], 'EBS:SnapshotUsageUnderBilling')
+            // This may be prefixed with the region abbrev, there are also
+            // suffixes like `UnderBilling` and `.outposts`
+            return Utils.endsWith(price.attributes['aws:ec2:usagetype'], "EBS:SnapshotUsage")
         })
     }
 


### PR DESCRIPTION
With the introduction of Outposts EBS snapshot pricing, this broke the matching here. Use a more robust string matching to skip over these.

Fixes #29 