### PR TITLE
Add support for io2 including tiered pricing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ The generic function for computing storage cost accepts an optional settings ran
 
 The supported parameters are:
 
-* `volumeType`: The type of volume (*magnetic*, *gp2*, *io1*, *st1* or *sc1*)
+* `volumeType`: The type of volume (*magnetic*, *gp2*, *io1*, *io2*, *st1* or *sc1*)
 * `volumeSize`: Size in number of provisioned Gigabytes
 * `region`: Will override any region in a settings range, eg: *us-east-2*
 
 There are several alias functions that embed the volumeType in the function name in the form:
 ```
-EC2_EBS_<MAGNETIC or GP2 or IO1 or ST1 or SC1>_GB(...)
+EC2_EBS_<MAGNETIC or GP2 or IO1 or IO2 or ST1 or SC1>_GB(...)
 ```
 
 For example, for General Purpose (gp2) storage you can also call:
@@ -143,10 +143,15 @@ For example, for General Purpose (gp2) storage you can also call:
 
 ### EBS Provisioned IOPS
 
-Provisioned IOPS pricing is only supported on *io1* volume types. Both functions take the number of *iops* to calculate for.
+Provisioned IOPS pricing is only supported on *io1* and *io2* volume types. Both functions take the number of *iops* to calculate for.
 
 * `EC2_EBS_IO1_IOPS(settingsRange, iops, region: optional)`
 * `EC2_EBS_IO1_IOPS(iops, region)`
+
+For IO2 IOPS, the functions are the same but will calculate rates using the tiered pricing model.
+
+* `EC2_EBS_IO2_IOPS(settingsRange, iops, region: optional)`
+* `EC2_EBS_IO2_IOPS(iops, region)`
 
 ### EBS Snapshot storage
 

--- a/scripts/gen-funcs.rb
+++ b/scripts/gen-funcs.rb
@@ -99,7 +99,7 @@ def gen_ebs(func_dir)
 
     EOF
 
-    vol_types = ['magnetic', 'gp2', 'st1', 'sc1', 'io1']
+    vol_types = ['magnetic', 'gp2', 'st1', 'sc1', 'io1', 'io2']
 
     vol_types.each do |vol_type|
         vol_type_up = vol_type.upcase

--- a/src/functions/ebs.ts
+++ b/src/functions/ebs.ts
@@ -120,6 +120,48 @@ export function EC2_EBS_IO1_IOPS(settingsOrIops, iopsOrRegion, region?) {
     return _ec2_ebs(settings, EBSStorageType.Iops, 'io1', volumeIops)
 }
 
+export function EC2_EBS_IO2_IOPS(settingsRange: Array<Array<string>>, iops: string | number, region?: string): number;
+export function EC2_EBS_IO2_IOPS(iops: string | number, region: string): number;
+
+/**
+ * Returns the hourly cost for the amount of provisioned EBS IO2 IOPS. Invoke as either:
+ * (settingsRange, iops[, region]) or (iops, region).
+ *
+ * @param {A2:B7 or 2500} settingsOrIops Settings range or number of iops
+ * @param {2500 or "us-east-2"} iopsOrRegion Number of iops or region
+ * @param {"us-east-2"} region AWS region (optional)
+ * @returns price
+ * @customfunction
+ */
+export function EC2_EBS_IO2_IOPS(settingsOrIops, iopsOrRegion, region?) {
+    _initContext()
+
+    let volumeIops: string = null
+    let settings: InvocationSettings = null
+
+    if (!settingsOrIops) {
+        throw `Must specify parameter`
+    }
+
+    if (typeof settingsOrIops === "string" || typeof settingsOrIops === "number") {
+        volumeIops = settingsOrIops.toString()
+
+        settings = InvocationSettings.loadFromMap({'region': iopsOrRegion})
+    } else {
+        let overrides = {}
+
+        if (region) {
+            overrides['region'] = region
+        }
+
+        volumeIops = iopsOrRegion.toString()
+
+        settings = InvocationSettings.loadFromRange(settingsOrIops, overrides)
+    }
+
+    return _ec2_ebs(settings, EBSStorageType.Iops, 'io2', volumeIops)
+}
+
 export function EC2_EBS_SNAPSHOT_GB(settingsRange: Array<Array<string>>, size: string | number, region?: string): number;
 export function EC2_EBS_SNAPSHOT_GB(size: string | number, region: string): number;
 

--- a/src/models/_storage_volume_price.ts
+++ b/src/models/_storage_volume_price.ts
@@ -1,0 +1,5 @@
+import { PriceConverter, PriceDuration } from "../price_converter";
+
+export abstract class StorageVolumePrice {
+  abstract totalPrice(duration: PriceDuration): number;
+}

--- a/src/models/storage_volume_price_flat.ts
+++ b/src/models/storage_volume_price_flat.ts
@@ -1,8 +1,9 @@
+import { StorageVolumePrice } from "./_storage_volume_price";
 import { PriceConverter, PriceDuration } from "../price_converter";
 
-export class StorageVolumePrice {
+export class StorageVolumePriceFlat extends StorageVolumePrice {
     constructor(private readonly price: any, private units: number) {
-
+        super()
     }
 
     totalPrice(duration: PriceDuration): number {

--- a/src/models/storage_volume_price_tiered.ts
+++ b/src/models/storage_volume_price_tiered.ts
@@ -1,0 +1,24 @@
+import { StorageVolumePrice } from "./_storage_volume_price";
+import { PriceConverter, PriceDuration } from "../price_converter";
+
+export class StorageVolumePriceTiered extends StorageVolumePrice {
+    constructor(private tiers: Array<number>, private readonly prices: Array<any>, private units: number) {
+        super()
+    }
+
+    totalPrice(duration: PriceDuration): number {
+        let total : number = 0.0
+        for (var i = this.tiers.length - 1; i >= 0; i--) {
+          if (this.units > this.tiers[i]) {
+            total += this.unitPrice(this.prices[i]) * (this.units - this.tiers[i])
+            this.units -= (this.units - this.tiers[i])
+          }
+        }
+
+        return PriceConverter.convert(total, duration, PriceDuration.Monthly)
+    }
+
+    private unitPrice(price: any): number {
+        return price.price.USD
+    }
+}

--- a/src/rds_storage_price.ts
+++ b/src/rds_storage_price.ts
@@ -1,7 +1,8 @@
 import { InvocationSettings } from "./settings/invocation_settings";
 import { RDSStorage } from "./models/rds_storage";
 import { PriceDuration } from "./price_converter";
-import { StorageVolumePrice } from "./models/storage_volume_price";
+import { StorageVolumePrice } from "./models/_storage_volume_price";
+import { StorageVolumePriceFlat } from "./models/storage_volume_price_flat";
 import { ctxt } from "./context";
 
 export class RDSStoragePrice {
@@ -34,7 +35,7 @@ export class RDSStoragePrice {
             throw `Too many matches for RDS storage type ${this.storageTypeStr()}`
         }
 
-        return new StorageVolumePrice(prices[0], this.storageSize)
+        return new StorageVolumePriceFlat(prices[0], this.storageSize)
     }
 
     private filterRDSStorage(prices) {

--- a/tests/functions/ebs_test.ts
+++ b/tests/functions/ebs_test.ts
@@ -1,7 +1,7 @@
 import { TestSuite } from "../_framework/test_suite";
 import { TestRun } from "../_framework/test_run";
-import { EC2_EBS_GP2_GB, EC2_EBS_MAGNETIC_GB, EC2_EBS_IO1_GB, EC2_EBS_ST1_GB, EC2_EBS_SC1_GB } from "../../src/functions/gen/ec2_ebs_gen";
-import { EC2_EBS_GB, EC2_EBS_IO1_IOPS, EC2_EBS_SNAPSHOT_GB } from "../../src/functions/ebs";
+import { EC2_EBS_GP2_GB, EC2_EBS_MAGNETIC_GB, EC2_EBS_IO1_GB, EC2_EBS_IO2_GB, EC2_EBS_ST1_GB, EC2_EBS_SC1_GB } from "../../src/functions/gen/ec2_ebs_gen";
+import { EC2_EBS_GB, EC2_EBS_IO1_IOPS, EC2_EBS_IO2_IOPS, EC2_EBS_SNAPSHOT_GB } from "../../src/functions/ebs";
 
 export class EBSFunctionTestSuite extends TestSuite {
     protected name(): string {
@@ -19,6 +19,19 @@ export class EBSFunctionTestSuite extends TestSuite {
             t.areClose(20000 * (0.072/730.0), EC2_EBS_IO1_IOPS(20000, "ca-central-1"), 0.000001)
         })
 
+        t.describe("EBS IO2 IOPs", () => {
+            t.areClose(15000 * (0.065/730.0), EC2_EBS_IO2_IOPS(15000, "us-east-1"), 0.000001)
+            t.areClose(20000 * (0.072/730.0), EC2_EBS_IO2_IOPS(20000, "ca-central-1"), 0.000001)
+        })
+
+        t.describe("EBS IO2 IOPs - tiered", () => {
+            t.areClose(32000 * (0.065/730.0) + (60000-32000) * (0.0455/730.0),
+             EC2_EBS_IO2_IOPS(60000, "us-east-1"), 0.000001)
+
+             t.areClose(32000 * (0.065/730.0) + 32000 * (0.0455/730.0) + (70000-64000) * (0.03185/730.0),
+             EC2_EBS_IO2_IOPS(70000, "us-east-1"), 0.000001)
+        })
+
         t.describe("EBS Snapshots", () => {
             t.areClose(2500 * (0.05/730.0), EC2_EBS_SNAPSHOT_GB(2500, "us-east-1"), 0.000001)
             t.areClose(5500 * (0.055/730.0), EC2_EBS_SNAPSHOT_GB(5500, "ca-central-1"), 0.000001)
@@ -27,6 +40,7 @@ export class EBSFunctionTestSuite extends TestSuite {
         t.describe("EBS storage tests", () => {
             t.areClose(550.0 * (0.05/730.0), EC2_EBS_MAGNETIC_GB(550.0, "us-east-1"), 0.000001)
             t.areClose(550.0 * (0.125/730.0), EC2_EBS_IO1_GB(550.0, "us-east-1"), 0.000001)
+            t.areClose(550.0 * (0.125/730.0), EC2_EBS_IO2_GB(550.0, "us-east-1"), 0.000001)
             t.areClose(550.0 * (0.045/730.0), EC2_EBS_ST1_GB(550.0, "us-east-1"), 0.000001)
             t.areClose(550.0 * (0.015/730.0), EC2_EBS_SC1_GB(550.0, "us-east-1"), 0.000001)
         })
@@ -47,6 +61,9 @@ export class EBSFunctionTestSuite extends TestSuite {
 
             t.areClose(10000 * (0.065/730.0), EC2_EBS_IO1_IOPS(s, 10000), 0.000001)
             t.areClose(10000 * (0.072/730.0), EC2_EBS_IO1_IOPS(s, 10000, "ca-central-1"), 0.000001)
+
+            t.areClose(10000 * (0.065/730.0), EC2_EBS_IO2_IOPS(s, 10000), 0.000001)
+            t.areClose(10000 * (0.072/730.0), EC2_EBS_IO2_IOPS(s, 10000, "ca-central-1"), 0.000001)
 
             t.areClose(4000 * (0.05/730.0), EC2_EBS_SNAPSHOT_GB(s, 4000), 0.000001)
             t.areClose(4000 * (0.055/730.0), EC2_EBS_SNAPSHOT_GB(s, 4000, "ca-central-1"), 0.000001)


### PR DESCRIPTION
This adds support for storage (GB) and IOPS pricing for the IO2 volume type. This includes support for the tiered pricing model of IO2 IOPS (0 - 32k, 32k - 64k, 64k+).

Fixes #31 