### PR TITLE
Add GP3 storage and IOPS pricing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ For example, for General Purpose (gp2) storage you can also call:
 
 ### EBS Provisioned IOPS
 
-Provisioned IOPS pricing is only supported on *io1* and *io2* volume types. Both functions take the number of *iops* to calculate for.
+Provisioned IOPS pricing is only supported on *io1*, *io2* and *gp3* volume types.
+Both functions take the number of *iops* to calculate for.
 
 * `EC2_EBS_IO1_IOPS(settingsRange, iops, region: optional)`
 * `EC2_EBS_IO1_IOPS(iops, region)`
@@ -152,6 +153,11 @@ For IO2 IOPS, the functions are the same but will calculate rates using the tier
 
 * `EC2_EBS_IO2_IOPS(settingsRange, iops, region: optional)`
 * `EC2_EBS_IO2_IOPS(iops, region)`
+
+For GP3 IOPS it is similar tiered pricing, but the first tier is free.
+
+* `EC2_EBS_GP3_IOPS(settingsRange, iops, region: optional)`
+* `EC2_EBS_GP3_IOPS(iops, region)`
 
 ### EBS Snapshot storage
 

--- a/scripts/gen-funcs.rb
+++ b/scripts/gen-funcs.rb
@@ -99,7 +99,7 @@ def gen_ebs(func_dir)
 
     EOF
 
-    vol_types = ['magnetic', 'gp2', 'st1', 'sc1', 'io1', 'io2']
+    vol_types = ['magnetic', 'gp2', 'gp3', 'st1', 'sc1', 'io1', 'io2']
 
     vol_types.each do |vol_type|
         vol_type_up = vol_type.upcase

--- a/src/functions/ebs.ts
+++ b/src/functions/ebs.ts
@@ -28,6 +28,33 @@ function _ec2_ebs(settings: InvocationSettings, storageType: EBSStorageType, vol
     return ebsPrices.get(PriceDuration.Hourly)
 }
 
+function _ec2_ebs_iops(volumeType: string, settingsOrIops, iopsOrRegion, region?) {
+    let volumeIops: string = null
+    let settings: InvocationSettings = null
+
+    if (!settingsOrIops) {
+        throw `Must specify parameter`
+    }
+
+    if (typeof settingsOrIops === "string" || typeof settingsOrIops === "number") {
+        volumeIops = settingsOrIops.toString()
+
+        settings = InvocationSettings.loadFromMap({'region': iopsOrRegion})
+    } else {
+        let overrides = {}
+
+        if (region) {
+            overrides['region'] = region
+        }
+
+        volumeIops = iopsOrRegion.toString()
+
+        settings = InvocationSettings.loadFromRange(settingsOrIops, overrides)
+    }
+
+    return _ec2_ebs(settings, EBSStorageType.Iops, volumeType, volumeIops)
+}
+
 export function EC2_EBS_GB(settingsRange: Array<Array<string>>, volumeType: string, volumeSize: string | number, region?: string): number;
 export function EC2_EBS_GB(volumeType: string, volumeSize: string | number, region: string): number
 
@@ -94,30 +121,7 @@ export function EC2_EBS_IO1_IOPS(iops: string | number, region: string): number;
 export function EC2_EBS_IO1_IOPS(settingsOrIops, iopsOrRegion, region?) {
     _initContext()
 
-    let volumeIops: string = null
-    let settings: InvocationSettings = null
-
-    if (!settingsOrIops) {
-        throw `Must specify parameter`
-    }
-
-    if (typeof settingsOrIops === "string" || typeof settingsOrIops === "number") {
-        volumeIops = settingsOrIops.toString()
-
-        settings = InvocationSettings.loadFromMap({'region': iopsOrRegion})
-    } else {
-        let overrides = {}
-
-        if (region) {
-            overrides['region'] = region
-        }
-
-        volumeIops = iopsOrRegion.toString()
-
-        settings = InvocationSettings.loadFromRange(settingsOrIops, overrides)
-    }
-
-    return _ec2_ebs(settings, EBSStorageType.Iops, 'io1', volumeIops)
+    return _ec2_ebs_iops('io1', settingsOrIops, iopsOrRegion, region)
 }
 
 export function EC2_EBS_IO2_IOPS(settingsRange: Array<Array<string>>, iops: string | number, region?: string): number;
@@ -136,30 +140,26 @@ export function EC2_EBS_IO2_IOPS(iops: string | number, region: string): number;
 export function EC2_EBS_IO2_IOPS(settingsOrIops, iopsOrRegion, region?) {
     _initContext()
 
-    let volumeIops: string = null
-    let settings: InvocationSettings = null
+    return _ec2_ebs_iops('io2', settingsOrIops, iopsOrRegion, region)
+}
 
-    if (!settingsOrIops) {
-        throw `Must specify parameter`
-    }
+export function EC2_EBS_GP3_IOPS(settingsRange: Array<Array<string>>, iops: string | number, region?: string): number;
+export function EC2_EBS_GP3_IOPS(iops: string | number, region: string): number;
 
-    if (typeof settingsOrIops === "string" || typeof settingsOrIops === "number") {
-        volumeIops = settingsOrIops.toString()
+/**
+ * Returns the hourly cost for the amount of provisioned EBS GP3 IOPS. Invoke as either:
+ * (settingsRange, iops[, region]) or (iops, region).
+ *
+ * @param {A2:B7 or 2500} settingsOrIops Settings range or number of iops
+ * @param {2500 or "us-east-2"} iopsOrRegion Number of iops or region
+ * @param {"us-east-2"} region AWS region (optional)
+ * @returns price
+ * @customfunction
+ */
+export function EC2_EBS_GP3_IOPS(settingsOrIops, iopsOrRegion, region?) {
+    _initContext()
 
-        settings = InvocationSettings.loadFromMap({'region': iopsOrRegion})
-    } else {
-        let overrides = {}
-
-        if (region) {
-            overrides['region'] = region
-        }
-
-        volumeIops = iopsOrRegion.toString()
-
-        settings = InvocationSettings.loadFromRange(settingsOrIops, overrides)
-    }
-
-    return _ec2_ebs(settings, EBSStorageType.Iops, 'io2', volumeIops)
+    return _ec2_ebs_iops('gp3', settingsOrIops, iopsOrRegion, region)
 }
 
 export function EC2_EBS_SNAPSHOT_GB(settingsRange: Array<Array<string>>, size: string | number, region?: string): number;

--- a/tests/functions/ebs_test.ts
+++ b/tests/functions/ebs_test.ts
@@ -1,7 +1,7 @@
 import { TestSuite } from "../_framework/test_suite";
 import { TestRun } from "../_framework/test_run";
-import { EC2_EBS_GP2_GB, EC2_EBS_MAGNETIC_GB, EC2_EBS_IO1_GB, EC2_EBS_IO2_GB, EC2_EBS_ST1_GB, EC2_EBS_SC1_GB } from "../../src/functions/gen/ec2_ebs_gen";
-import { EC2_EBS_GB, EC2_EBS_IO1_IOPS, EC2_EBS_IO2_IOPS, EC2_EBS_SNAPSHOT_GB } from "../../src/functions/ebs";
+import { EC2_EBS_GP2_GB, EC2_EBS_GP3_GB, EC2_EBS_MAGNETIC_GB, EC2_EBS_IO1_GB, EC2_EBS_IO2_GB, EC2_EBS_ST1_GB, EC2_EBS_SC1_GB } from "../../src/functions/gen/ec2_ebs_gen";
+import { EC2_EBS_GB, EC2_EBS_IO1_IOPS, EC2_EBS_IO2_IOPS, EC2_EBS_GP3_IOPS, EC2_EBS_SNAPSHOT_GB } from "../../src/functions/ebs";
 
 export class EBSFunctionTestSuite extends TestSuite {
     protected name(): string {
@@ -12,6 +12,11 @@ export class EBSFunctionTestSuite extends TestSuite {
         t.describe("EBS GP2", () => {
             t.areClose(400.0 * (0.10/730.0), EC2_EBS_GP2_GB("400", "us-east-1"), 0.000001)
             t.areClose(400.0 * (0.10/730.0), EC2_EBS_GP2_GB("400", "us-east-2"), 0.000001)
+        })
+
+        t.describe("EBS GP3", () => {
+            t.areClose(400.0 * (0.08/730.0), EC2_EBS_GP3_GB("400", "us-east-1"), 0.000001)
+            t.areClose(400.0 * (0.08/730.0), EC2_EBS_GP3_GB("400", "us-east-2"), 0.000001)
         })
 
         t.describe("EBS IO1 IOPs", () => {
@@ -30,6 +35,12 @@ export class EBSFunctionTestSuite extends TestSuite {
 
              t.areClose(32000 * (0.065/730.0) + 32000 * (0.0455/730.0) + (70000-64000) * (0.03185/730.0),
              EC2_EBS_IO2_IOPS(70000, "us-east-1"), 0.000001)
+        })
+
+        t.describe("EBS GP3 IOPs - tiered", () => {
+            t.areClose(0.0, EC2_EBS_GP3_IOPS(2800, "us-east-1"), 0.000001)
+
+             t.areClose((7000 - 3000) * (0.005/730.0), EC2_EBS_GP3_IOPS(7000, "us-east-1"), 0.000001)
         })
 
         t.describe("EBS Snapshots", () => {
@@ -75,7 +86,7 @@ export class EBSFunctionTestSuite extends TestSuite {
             ]
 
             t.willThrow(function() {
-                EC2_EBS_GB(s, "gp3", 400)
+                EC2_EBS_GB(s, "gp1", 400)
             }, "invalid EBS volume type")
 
             t.willThrow(function() {


### PR DESCRIPTION
Supports GP3 storage pricing and provisioned IOPS. IOPS are tiered like IO2, but the first tier is free up to 3k.

Fixes #32 